### PR TITLE
Add MLOps environment with Docker Compose

### DIFF
--- a/MLOps/README.md
+++ b/MLOps/README.md
@@ -1,0 +1,32 @@
+# Entorno MLOps
+
+Este directorio contiene un entorno básico para pruebas de MLOps utilizando Docker Compose.
+Incluye los siguientes servicios:
+
+* **PostgreSQL**: base de datos para MLflow.
+* **MinIO**: almacén de artefactos compatible con S3.
+* **MLflow**: servidor de seguimiento de experimentos.
+* **Jupyter Notebook**: entorno interactivo para el desarrollo.
+
+## Requisitos
+
+Necesitas tener instalados Docker y Docker Compose en tu sistema. Consulta la carpeta `docker` de este repositorio para instrucciones de instalación.
+
+## Puesta en marcha
+
+1. Entra en la carpeta `MLOps`.
+2. Ejecuta `docker-compose up` para iniciar todos los servicios.
+3. Accede a los servicios a través de los puertos indicados más abajo.
+
+## Servicios disponibles
+
+* **MLflow** – [http://localhost:5000](http://localhost:5000)
+* **Jupyter Notebook** – [http://localhost:8888](http://localhost:8888) (token "mlops")
+* **MinIO** – [http://localhost:9001](http://localhost:9001) (usuario "minio", password "minio123")
+
+Los datos se almacenan en volúmenes Docker para que no se pierdan entre reinicios.
+
+## Parar el entorno
+
+Con `Ctrl+C` se detendrán los servicios en primer plano. También puedes ejecutar `docker-compose down`.
+

--- a/MLOps/docker-compose.yaml
+++ b/MLOps/docker-compose.yaml
@@ -1,0 +1,54 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:13
+    restart: always
+    environment:
+      POSTGRES_USER: mlflow
+      POSTGRES_PASSWORD: mlflow
+      POSTGRES_DB: mlflow
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+  mlflow:
+    image: ghcr.io/mlflow/mlflow:v2.6.0
+    depends_on:
+      - postgres
+      - minio
+    command: >
+      mlflow server --backend-store-uri postgresql://mlflow:mlflow@postgres:5432/mlflow \
+                   --default-artifact-root s3://mlflow/ --host 0.0.0.0 --port 5000
+    environment:
+      AWS_ACCESS_KEY_ID: minio
+      AWS_SECRET_ACCESS_KEY: minio123
+      MLFLOW_S3_ENDPOINT_URL: http://minio:9000
+    ports:
+      - "5000:5000"
+
+  jupyter:
+    image: jupyter/scipy-notebook
+    environment:
+      JUPYTER_TOKEN: mlops
+    volumes:
+      - ./notebooks:/home/jovyan/work
+    ports:
+      - "8888:8888"
+
+volumes:
+  postgres_data:
+  minio_data:

--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 
 Esto es un repo donde subo todo el código que uso para sistemas. 
 Voy a tratar de mantenerlo actualizado.
+
+## Directorios destacados
+- `docker` – Imágenes y composes para distintos servicios.
+- `kubernetes` – Notas de instalación de K3s y herramientas asociadas.
+- `MLOps` – Entorno de pruebas para operaciones de Machine Learning.


### PR DESCRIPTION
## Summary
- add `MLOps` directory with docker-compose setup for MLflow, Jupyter, MinIO and PostgreSQL
- include notebooks folder and usage instructions
- document the new directory in the main README

## Testing
- `docker-compose -f MLOps/docker-compose.yaml config` *(fails: docker-compose not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68591cd07c5c832f86fb30782f2894a7